### PR TITLE
[CORE] Enabled NO_GL_FINISH due to issues with Win 10 GTX 770 and the…

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -950,7 +950,10 @@ void sad::Renderer::renderScenes()
     this->unlockRendering();
 }
 
-//#define NO_GL_FINISH
+// Temporarily disabled due to issues with explicitly calling glFinish() on Windows 10 GTX770, since
+// sometimes window becomes unresponsible and even crashes on such cases. Removing it does nothing,
+// everything still goes normally. 
+#define NO_GL_FINISH
 
 void sad::Renderer::finishRendering()
 {


### PR DESCRIPTION
…ir absence with enabled flag in all other cases.