### PR TITLE
Issue 156

### DIFF
--- a/include/texture.h
+++ b/include/texture.h
@@ -321,7 +321,7 @@ private:
     /*! Checks for errors in work of OpenGL and converts them into string
         \return string with error description (NULL if there wasn't any error)
     */
-    unsigned char const * checkForErrors();
+    unsigned char const * getGLError();
 };
 
 }

--- a/include/texture.h
+++ b/include/texture.h
@@ -318,10 +318,10 @@ protected:
      */
     sad::Renderer * m_renderer;
 private:
-	/*! Checks for errors in work of OpenGL and sends message to log (internal message)
-		\param[in] render if render is NULL sends error to global log else sends error to local log of render
+	/*! Checks for errors in work of OpenGL and converts them into string
+		\return string with error description (NULL if there wasn't any error)
 	*/
-	void checkForErrors(sad::Renderer * render);
+	unsigned char const * checkForErrors();
 };
 
 }

--- a/include/texture.h
+++ b/include/texture.h
@@ -317,6 +317,11 @@ protected:
     /*! A renderer, which is held by a texture
      */
     sad::Renderer * m_renderer;
+private:
+	/*! Checks for errors in work of OpenGL and sends message to log (internal message)
+		\param[in] render if render is NULL sends error to global log else sends error to local log of render
+	*/
+	void checkForErrors(sad::Renderer * render);
 };
 
 }

--- a/include/texture.h
+++ b/include/texture.h
@@ -318,10 +318,10 @@ protected:
      */
     sad::Renderer * m_renderer;
 private:
-	/*! Checks for errors in work of OpenGL and converts them into string
-		\return string with error description (NULL if there wasn't any error)
-	*/
-	unsigned char const * checkForErrors();
+    /*! Checks for errors in work of OpenGL and converts them into string
+        \return string with error description (NULL if there wasn't any error)
+    */
+    unsigned char const * checkForErrors();
 };
 
 }

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -206,7 +206,7 @@ void sad::Texture::upload()
     glGenTextures(1, static_cast<GLuint *>(&Id));
     // glGenTextures can cause GL_INVALID_VALUE if n (1st arg) is negative.
     // Call function to know if there was any error and send message to log if error occurred
-    gl_error = checkForErrors();
+    gl_error = getGLError();
     if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
 
@@ -217,7 +217,7 @@ void sad::Texture::upload()
     */
     glBindTexture(GL_TEXTURE_2D, Id);
     // Call function to know if there was any error and send message to log if error occurred
-    gl_error = checkForErrors();
+    gl_error = getGLError();
     if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
 
@@ -227,7 +227,7 @@ void sad::Texture::upload()
     */
     glPixelStorei(GL_UNPACK_ALIGNMENT,1);
     // Call function to know if there was any error and send message to log if error occurred
-    gl_error = checkForErrors();
+    gl_error = getGLError();
     if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
 
@@ -236,13 +236,13 @@ void sad::Texture::upload()
     */
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
     // Call function to know if there was any error and send message to log if error occurred
-    gl_error = checkForErrors();
+    gl_error = getGLError();
     if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
     // Call function to know if there was any error and send message to log if error occurred
-    gl_error = checkForErrors();
+    gl_error = getGLError();
     if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
     
@@ -250,20 +250,20 @@ void sad::Texture::upload()
     {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
         // Call function to know if there was any error and send message to log if error occurred
-        gl_error = checkForErrors();
+        gl_error = getGLError();
         if (gl_error != NULL)
             SL_COND_LOCAL_INTERNAL(gl_error, r);
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
         // Call function to know if there was any error and send message to log if error occurred
-        gl_error = checkForErrors();
+        gl_error = getGLError();
         if (gl_error != NULL)
             SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
 
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     // Call function to know if there was any error and send message to log if error occurred
-    gl_error = checkForErrors();
+    gl_error = getGLError();
     if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
 
@@ -271,7 +271,7 @@ void sad::Texture::upload()
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
         // Call function to know if there was any error and send message to log if error occurred
-        gl_error = checkForErrors();
+        gl_error = getGLError();
         if (gl_error != NULL)
             SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
@@ -279,7 +279,7 @@ void sad::Texture::upload()
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         // Call function to know if there was any error and send message to log if error occurred
-        gl_error = checkForErrors();
+        gl_error = getGLError();
         if (gl_error != NULL)
             SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
@@ -299,7 +299,7 @@ void sad::Texture::upload()
             */
             res = gluBuild2DMipmaps(GL_TEXTURE_2D, components, Width, Height, opengl_format, opengl10_type, Buffer->buffer());
             // Call function to know if there was any error and send message to log if error occurred
-            gl_error = checkForErrors();
+            gl_error = getGLError();
             if (gl_error != NULL)
                 SL_COND_LOCAL_INTERNAL(gl_error, r);
         }
@@ -309,7 +309,7 @@ void sad::Texture::upload()
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); 
                 // Call function to know if there was any error and send message to log if error occurred
-                gl_error = checkForErrors();
+                gl_error = getGLError();
                 if (gl_error != NULL)
                     SL_COND_LOCAL_INTERNAL(gl_error, r);
             }
@@ -317,7 +317,7 @@ void sad::Texture::upload()
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_FALSE);
                 // Call function to know if there was any error and send message to log if error occurred
-                gl_error = checkForErrors();
+                gl_error = getGLError();
                 if (gl_error != NULL)
                     SL_COND_LOCAL_INTERNAL(gl_error, r);
             }
@@ -485,7 +485,7 @@ void sad::Texture::bind()
         upload();
     glBindTexture(GL_TEXTURE_2D, Id);
     // Call function to know if there was any error and send message to log if error occurred
-    unsigned char const * gl_error = checkForErrors();
+    unsigned char const * gl_error = getGLError();
     if (gl_error != NULL)
         SL_INTERNAL(gl_error);
 #endif
@@ -499,7 +499,7 @@ void sad::Texture::unload()
         // glDeleteTextures causes an GL_INVALID_VALUE if n (1st arg) is negative.
         glDeleteTextures(1, &Id);
         // Call function to know if there was any error and send message to log if error occurred
-        unsigned char const * gl_error = checkForErrors();
+        unsigned char const * gl_error = getGLError();
         if (gl_error != NULL)
             SL_INTERNAL(gl_error);
     }
@@ -610,7 +610,7 @@ void sad::Texture::convertToPOTTexture()
     this->Buffer = buffer;
 }
 
-unsigned char const * sad::Texture::checkForErrors() {
+unsigned char const * sad::Texture::getGLError() {
     // Get an info about errors during operation
     GLint errorcode = glGetError();
     // If there is an error return its description

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -545,17 +545,12 @@ void sad::Texture::convertToPOTTexture()
     this->Buffer = buffer;
 }
 
-void sad::Texture::checkForErrors(sad::Renderer * render) {
+unsigned char const * sad::Texture::checkForErrors() {
 	// Get an info about errors during operation
 	GLint errorcode = glGetError();
-	// If there is an error add it to the log (internal message)
+	// If there is an error return its description
 	if (errorcode)
-	{
-		// If there is no render send message to global log
-		if (render == NULL)
-			SL_INTERNAL(gluErrorString(errorcode));
-		// Else send message to local log of render
-		else
-			SL_COND_LOCAL_INTERNAL(gluErrorString(errorcode), render);
-	}
+		return gluErrorString(errorcode);
+	// Else return NULL
+	return NULL;
 }

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -207,7 +207,7 @@ void sad::Texture::upload()
     // glGenTextures can cause GL_INVALID_VALUE if n (1st arg) is negative.
     // Call function to know if there was any error and send message to log if error occurred
     gl_error = checkForErrors();
-    if(gl_error!=NULL)
+    if (gl_error != NULL)
         SL_COND_LOCAL_INTERNAL(gl_error, r);
 
     /* Possible errors:

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -523,3 +523,18 @@ void sad::Texture::convertToPOTTexture()
     delete this->Buffer;
     this->Buffer = buffer;
 }
+
+void sad::Texture::checkForErrors(sad::Renderer * render) {
+	// Get an info about errors during operation
+	GLint errorcode = glGetError();
+	// If there is an error add it to the log (internal message)
+	if (errorcode)
+	{
+		// If there is no render send message to global log
+		if (render == NULL)
+			SL_INTERNAL(gluErrorString(errorcode));
+		// Else send message to local log of render
+		else
+			SL_COND_LOCAL_INTERNAL(gluErrorString(errorcode), render);
+	}
+}

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -202,9 +202,24 @@ void sad::Texture::upload()
     }
     // Create ID of texture and bind it
     glGenTextures(1, static_cast<GLuint *>(&Id));
+	// glGenTextures can cause GL_INVALID_VALUE if n (1st arg) is negative.
+
+	/* Possible errors:
+	GL_INVALID_ENUM is generated if target (1st arg) is not one of the allowable values.
+	GL_INVALID_VALUE is generated if texture is not a name returned from a previous call to glGenTextures.
+	GL_INVALID_OPERATION is generated if texture was previously created with a target that doesn't match that of target.
+	*/
     glBindTexture(GL_TEXTURE_2D, Id);
 
-    glPixelStorei(GL_UNPACK_ALIGNMENT,1);   
+	/* Possible errors:
+	GL_INVALID_ENUM is generated if pname (1st arg) is not an accepted value.
+	GL_INVALID_VALUE is generated if a negative row length, pixel skip, or row skip value is specified, or if alignment is specified as other than 1, 2, 4, or 8.
+	*/
+    glPixelStorei(GL_UNPACK_ALIGNMENT,1);
+
+	/* Possible errors:
+	GL_INVALID_ENUM, GL_INVALID_OPERATION, GL_INVALID_VALUE, GL_TEXTURE_BASE_LEVEL
+	*/
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
     
@@ -234,6 +249,9 @@ void sad::Texture::upload()
         if (version.p1() == 1 && version.p2() < 4)
         {
             // In case of OpenGL <1.4 there is not much we can do, so we ignore BuildMipMap flags
+			/* Possible errors:
+			GL_INVALID_ENUM , GL_INVALID_OPERATION, GL_INVALID_VALUE
+			*/
             res = gluBuild2DMipmaps(GL_TEXTURE_2D, components, Width, Height, opengl_format, opengl10_type, Buffer->buffer());
         }
         else
@@ -415,8 +433,11 @@ void sad::Texture::bind()
 void sad::Texture::unload()
 {
 #ifndef TEXTURE_LOADER_TEST
-    if (OnGPU)
-        glDeleteTextures(1, &Id);
+	if (OnGPU)
+	{
+		// glDeleteTextures causes an GL_INVALID_VALUE if n (1st arg) is negative.
+		glDeleteTextures(1, &Id);
+	}
     OnGPU = false;
 #endif
 }

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -200,9 +200,15 @@ void sad::Texture::upload()
             convertToPOTTexture();
         }
     }
+	// String that contains an error description after OpenGL funstions calls
+	unsigned char const * gl_error;
     // Create ID of texture and bind it
     glGenTextures(1, static_cast<GLuint *>(&Id));
 	// glGenTextures can cause GL_INVALID_VALUE if n (1st arg) is negative.
+	// Call function to know if there was any error and send message to log if error occurred
+	gl_error = checkForErrors();
+	if(gl_error!=NULL)
+		SL_COND_LOCAL_INTERNAL(gl_error, r);
 
 	/* Possible errors:
 	GL_INVALID_ENUM is generated if target (1st arg) is not one of the allowable values.
@@ -210,33 +216,72 @@ void sad::Texture::upload()
 	GL_INVALID_OPERATION is generated if texture was previously created with a target that doesn't match that of target.
 	*/
     glBindTexture(GL_TEXTURE_2D, Id);
+	// Call function to know if there was any error and send message to log if error occurred
+	gl_error = checkForErrors();
+	if (gl_error != NULL)
+		SL_COND_LOCAL_INTERNAL(gl_error, r);
 
 	/* Possible errors:
 	GL_INVALID_ENUM is generated if pname (1st arg) is not an accepted value.
 	GL_INVALID_VALUE is generated if a negative row length, pixel skip, or row skip value is specified, or if alignment is specified as other than 1, 2, 4, or 8.
 	*/
     glPixelStorei(GL_UNPACK_ALIGNMENT,1);
+	// Call function to know if there was any error and send message to log if error occurred
+	gl_error = checkForErrors();
+	if (gl_error != NULL)
+		SL_COND_LOCAL_INTERNAL(gl_error, r);
 
 	/* Possible errors:
 	GL_INVALID_ENUM, GL_INVALID_OPERATION, GL_INVALID_VALUE, GL_TEXTURE_BASE_LEVEL
 	*/
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+	// Call function to know if there was any error and send message to log if error occurred
+	gl_error = checkForErrors();
+	if (gl_error != NULL)
+		SL_COND_LOCAL_INTERNAL(gl_error, r);
+
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+	// Call function to know if there was any error and send message to log if error occurred
+	gl_error = checkForErrors();
+	if (gl_error != NULL)
+		SL_COND_LOCAL_INTERNAL(gl_error, r);
     
     if (!BuildMipMaps)
     {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+		// Call function to know if there was any error and send message to log if error occurred
+		gl_error = checkForErrors();
+		if (gl_error != NULL)
+			SL_COND_LOCAL_INTERNAL(gl_error, r);
+
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+		// Call function to know if there was any error and send message to log if error occurred
+		gl_error = checkForErrors();
+		if (gl_error != NULL)
+			SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
 
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	// Call function to know if there was any error and send message to log if error occurred
+	gl_error = checkForErrors();
+	if (gl_error != NULL)
+		SL_COND_LOCAL_INTERNAL(gl_error, r);
+
     if (BuildMipMaps)
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+		// Call function to know if there was any error and send message to log if error occurred
+		gl_error = checkForErrors();
+		if (gl_error != NULL)
+			SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
     else
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		// Call function to know if there was any error and send message to log if error occurred
+		gl_error = checkForErrors();
+		if (gl_error != NULL)
+			SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
 
     // Actually upload image to GPU   
@@ -253,16 +298,28 @@ void sad::Texture::upload()
 			GL_INVALID_ENUM , GL_INVALID_OPERATION, GL_INVALID_VALUE
 			*/
             res = gluBuild2DMipmaps(GL_TEXTURE_2D, components, Width, Height, opengl_format, opengl10_type, Buffer->buffer());
+			// Call function to know if there was any error and send message to log if error occurred
+			gl_error = checkForErrors();
+			if (gl_error != NULL)
+				SL_COND_LOCAL_INTERNAL(gl_error, r);
         }
         else
         {
             if (BuildMipMaps)
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); 
+				// Call function to know if there was any error and send message to log if error occurred
+				gl_error = checkForErrors();
+				if (gl_error != NULL)
+					SL_COND_LOCAL_INTERNAL(gl_error, r);
             }
             else
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_FALSE);
+				// Call function to know if there was any error and send message to log if error occurred
+				gl_error = checkForErrors();
+				if (gl_error != NULL)
+					SL_COND_LOCAL_INTERNAL(gl_error, r);
             }
             glTexImage2D(GL_TEXTURE_2D, 0, opengl_internalformat, Width, Height, 0, opengl_format, opengl_type, Buffer->buffer());
             res = glGetError();
@@ -427,6 +484,10 @@ void sad::Texture::bind()
     if (!OnGPU)
         upload();
     glBindTexture(GL_TEXTURE_2D, Id);
+	// Call function to know if there was any error and send message to log if error occurred
+	unsigned char const * gl_error = checkForErrors();
+	if (gl_error != NULL)
+		SL_INTERNAL(gl_error);
 #endif
 }
 
@@ -437,6 +498,10 @@ void sad::Texture::unload()
 	{
 		// glDeleteTextures causes an GL_INVALID_VALUE if n (1st arg) is negative.
 		glDeleteTextures(1, &Id);
+		// Call function to know if there was any error and send message to log if error occurred
+		unsigned char const * gl_error = checkForErrors();
+		if (gl_error != NULL)
+			SL_INTERNAL(gl_error);
 	}
     OnGPU = false;
 #endif

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -200,88 +200,88 @@ void sad::Texture::upload()
             convertToPOTTexture();
         }
     }
-	// String that contains an error description after OpenGL funstions calls
-	unsigned char const * gl_error;
+    // String that contains an error description after OpenGL funstions calls
+    unsigned char const * gl_error;
     // Create ID of texture and bind it
     glGenTextures(1, static_cast<GLuint *>(&Id));
-	// glGenTextures can cause GL_INVALID_VALUE if n (1st arg) is negative.
-	// Call function to know if there was any error and send message to log if error occurred
-	gl_error = checkForErrors();
-	if(gl_error!=NULL)
-		SL_COND_LOCAL_INTERNAL(gl_error, r);
+    // glGenTextures can cause GL_INVALID_VALUE if n (1st arg) is negative.
+    // Call function to know if there was any error and send message to log if error occurred
+    gl_error = checkForErrors();
+    if(gl_error!=NULL)
+        SL_COND_LOCAL_INTERNAL(gl_error, r);
 
-	/* Possible errors:
-	GL_INVALID_ENUM is generated if target (1st arg) is not one of the allowable values.
-	GL_INVALID_VALUE is generated if texture is not a name returned from a previous call to glGenTextures.
-	GL_INVALID_OPERATION is generated if texture was previously created with a target that doesn't match that of target.
-	*/
+    /* Possible errors:
+    GL_INVALID_ENUM is generated if target (1st arg) is not one of the allowable values.
+    GL_INVALID_VALUE is generated if texture is not a name returned from a previous call to glGenTextures.
+    GL_INVALID_OPERATION is generated if texture was previously created with a target that doesn't match that of target.
+    */
     glBindTexture(GL_TEXTURE_2D, Id);
-	// Call function to know if there was any error and send message to log if error occurred
-	gl_error = checkForErrors();
-	if (gl_error != NULL)
-		SL_COND_LOCAL_INTERNAL(gl_error, r);
+    // Call function to know if there was any error and send message to log if error occurred
+    gl_error = checkForErrors();
+    if (gl_error != NULL)
+        SL_COND_LOCAL_INTERNAL(gl_error, r);
 
-	/* Possible errors:
-	GL_INVALID_ENUM is generated if pname (1st arg) is not an accepted value.
-	GL_INVALID_VALUE is generated if a negative row length, pixel skip, or row skip value is specified, or if alignment is specified as other than 1, 2, 4, or 8.
-	*/
+    /* Possible errors:
+    GL_INVALID_ENUM is generated if pname (1st arg) is not an accepted value.
+    GL_INVALID_VALUE is generated if a negative row length, pixel skip, or row skip value is specified, or if alignment is specified as other than 1, 2, 4, or 8.
+    */
     glPixelStorei(GL_UNPACK_ALIGNMENT,1);
-	// Call function to know if there was any error and send message to log if error occurred
-	gl_error = checkForErrors();
-	if (gl_error != NULL)
-		SL_COND_LOCAL_INTERNAL(gl_error, r);
+    // Call function to know if there was any error and send message to log if error occurred
+    gl_error = checkForErrors();
+    if (gl_error != NULL)
+        SL_COND_LOCAL_INTERNAL(gl_error, r);
 
-	/* Possible errors:
-	GL_INVALID_ENUM, GL_INVALID_OPERATION, GL_INVALID_VALUE, GL_TEXTURE_BASE_LEVEL
-	*/
+    /* Possible errors:
+    GL_INVALID_ENUM, GL_INVALID_OPERATION, GL_INVALID_VALUE, GL_TEXTURE_BASE_LEVEL
+    */
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-	// Call function to know if there was any error and send message to log if error occurred
-	gl_error = checkForErrors();
-	if (gl_error != NULL)
-		SL_COND_LOCAL_INTERNAL(gl_error, r);
+    // Call function to know if there was any error and send message to log if error occurred
+    gl_error = checkForErrors();
+    if (gl_error != NULL)
+        SL_COND_LOCAL_INTERNAL(gl_error, r);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-	// Call function to know if there was any error and send message to log if error occurred
-	gl_error = checkForErrors();
-	if (gl_error != NULL)
-		SL_COND_LOCAL_INTERNAL(gl_error, r);
+    // Call function to know if there was any error and send message to log if error occurred
+    gl_error = checkForErrors();
+    if (gl_error != NULL)
+        SL_COND_LOCAL_INTERNAL(gl_error, r);
     
     if (!BuildMipMaps)
     {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-		// Call function to know if there was any error and send message to log if error occurred
-		gl_error = checkForErrors();
-		if (gl_error != NULL)
-			SL_COND_LOCAL_INTERNAL(gl_error, r);
+        // Call function to know if there was any error and send message to log if error occurred
+        gl_error = checkForErrors();
+        if (gl_error != NULL)
+            SL_COND_LOCAL_INTERNAL(gl_error, r);
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
-		// Call function to know if there was any error and send message to log if error occurred
-		gl_error = checkForErrors();
-		if (gl_error != NULL)
-			SL_COND_LOCAL_INTERNAL(gl_error, r);
+        // Call function to know if there was any error and send message to log if error occurred
+        gl_error = checkForErrors();
+        if (gl_error != NULL)
+            SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
 
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	// Call function to know if there was any error and send message to log if error occurred
-	gl_error = checkForErrors();
-	if (gl_error != NULL)
-		SL_COND_LOCAL_INTERNAL(gl_error, r);
+    // Call function to know if there was any error and send message to log if error occurred
+    gl_error = checkForErrors();
+    if (gl_error != NULL)
+        SL_COND_LOCAL_INTERNAL(gl_error, r);
 
     if (BuildMipMaps)
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
-		// Call function to know if there was any error and send message to log if error occurred
-		gl_error = checkForErrors();
-		if (gl_error != NULL)
-			SL_COND_LOCAL_INTERNAL(gl_error, r);
+        // Call function to know if there was any error and send message to log if error occurred
+        gl_error = checkForErrors();
+        if (gl_error != NULL)
+            SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
     else
     {
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		// Call function to know if there was any error and send message to log if error occurred
-		gl_error = checkForErrors();
-		if (gl_error != NULL)
-			SL_COND_LOCAL_INTERNAL(gl_error, r);
+        // Call function to know if there was any error and send message to log if error occurred
+        gl_error = checkForErrors();
+        if (gl_error != NULL)
+            SL_COND_LOCAL_INTERNAL(gl_error, r);
     }
 
     // Actually upload image to GPU   
@@ -294,32 +294,32 @@ void sad::Texture::upload()
         if (version.p1() == 1 && version.p2() < 4)
         {
             // In case of OpenGL <1.4 there is not much we can do, so we ignore BuildMipMap flags
-			/* Possible errors:
-			GL_INVALID_ENUM , GL_INVALID_OPERATION, GL_INVALID_VALUE
-			*/
+            /* Possible errors:
+            GL_INVALID_ENUM , GL_INVALID_OPERATION, GL_INVALID_VALUE
+            */
             res = gluBuild2DMipmaps(GL_TEXTURE_2D, components, Width, Height, opengl_format, opengl10_type, Buffer->buffer());
-			// Call function to know if there was any error and send message to log if error occurred
-			gl_error = checkForErrors();
-			if (gl_error != NULL)
-				SL_COND_LOCAL_INTERNAL(gl_error, r);
+            // Call function to know if there was any error and send message to log if error occurred
+            gl_error = checkForErrors();
+            if (gl_error != NULL)
+                SL_COND_LOCAL_INTERNAL(gl_error, r);
         }
         else
         {
             if (BuildMipMaps)
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE); 
-				// Call function to know if there was any error and send message to log if error occurred
-				gl_error = checkForErrors();
-				if (gl_error != NULL)
-					SL_COND_LOCAL_INTERNAL(gl_error, r);
+                // Call function to know if there was any error and send message to log if error occurred
+                gl_error = checkForErrors();
+                if (gl_error != NULL)
+                    SL_COND_LOCAL_INTERNAL(gl_error, r);
             }
             else
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_FALSE);
-				// Call function to know if there was any error and send message to log if error occurred
-				gl_error = checkForErrors();
-				if (gl_error != NULL)
-					SL_COND_LOCAL_INTERNAL(gl_error, r);
+                // Call function to know if there was any error and send message to log if error occurred
+                gl_error = checkForErrors();
+                if (gl_error != NULL)
+                    SL_COND_LOCAL_INTERNAL(gl_error, r);
             }
             glTexImage2D(GL_TEXTURE_2D, 0, opengl_internalformat, Width, Height, 0, opengl_format, opengl_type, Buffer->buffer());
             res = glGetError();
@@ -484,25 +484,25 @@ void sad::Texture::bind()
     if (!OnGPU)
         upload();
     glBindTexture(GL_TEXTURE_2D, Id);
-	// Call function to know if there was any error and send message to log if error occurred
-	unsigned char const * gl_error = checkForErrors();
-	if (gl_error != NULL)
-		SL_INTERNAL(gl_error);
+    // Call function to know if there was any error and send message to log if error occurred
+    unsigned char const * gl_error = checkForErrors();
+    if (gl_error != NULL)
+        SL_INTERNAL(gl_error);
 #endif
 }
 
 void sad::Texture::unload()
 {
 #ifndef TEXTURE_LOADER_TEST
-	if (OnGPU)
-	{
-		// glDeleteTextures causes an GL_INVALID_VALUE if n (1st arg) is negative.
-		glDeleteTextures(1, &Id);
-		// Call function to know if there was any error and send message to log if error occurred
-		unsigned char const * gl_error = checkForErrors();
-		if (gl_error != NULL)
-			SL_INTERNAL(gl_error);
-	}
+    if (OnGPU)
+    {
+        // glDeleteTextures causes an GL_INVALID_VALUE if n (1st arg) is negative.
+        glDeleteTextures(1, &Id);
+        // Call function to know if there was any error and send message to log if error occurred
+        unsigned char const * gl_error = checkForErrors();
+        if (gl_error != NULL)
+            SL_INTERNAL(gl_error);
+    }
     OnGPU = false;
 #endif
 }
@@ -611,11 +611,11 @@ void sad::Texture::convertToPOTTexture()
 }
 
 unsigned char const * sad::Texture::checkForErrors() {
-	// Get an info about errors during operation
-	GLint errorcode = glGetError();
-	// If there is an error return its description
-	if (errorcode)
-		return gluErrorString(errorcode);
-	// Else return NULL
-	return NULL;
+    // Get an info about errors during operation
+    GLint errorcode = glGetError();
+    // If there is an error return its description
+    if (errorcode)
+        return gluErrorString(errorcode);
+    // Else return NULL
+    return NULL;
 }


### PR DESCRIPTION
Added error checks to sad::Texture (src/texture.cpp).

Method of class sad::Texture `unsigned char const * sad::Texture::checkForErrors()` gets an error of OpenGL and returns its string representation. If there wasn't any error, method returns NULL.

This allows to watch for errors by sending their string description to log. Due to the fact that log shows location in code file from where the message was sent, `checkForErrors()` can't send messages inside itself because it will create troubles with localization of error.